### PR TITLE
fix: dont return ns for cnames

### DIFF
--- a/domain.py
+++ b/domain.py
@@ -22,10 +22,15 @@ class Domain:
             return []
 
     def fetch_std_records(self):
-        self.NS = self.query("NS")
+        self.CNAME = self.query("CNAME")
         self.A = self.query("A")
         self.AAAA = self.query("AAAA")
-        self.CNAME = self.query("CNAME")
+        if self.CNAME:
+            # return early if we get a CNAME otherwise we get records for the cname aswell
+            # this is actually desirable for A/AAAA but not NS as the next zone
+            # will be queried based on the CNAME value, not the original domain
+            return
+        self.NS = self.query("NS")
 
     def __init__(self, domain, fetch_standard_records=True, ns=None):
         self.domain = domain


### PR DESCRIPTION
DNS is hard!

If a domain has a CNAME:
* An NS check will return the NS for the CNAME value, but the resolver will modify queries to use subdomain.cname (rather than subdomain.originaldomain when querying the NS.  
* An A record check will be resolved likewise against the CNAME value, but this is useful as it allows to look for ip matches if they are hidden behind a cname
* An AAAA record check will be resolved likewise against the CNAME value, but this is useful as it allows to look for ip matches if they are hidden behind a cname

In this PR, I stop NS checks from being performed if a CNAME is found.