### PR TITLE
style: Capitalize description of --help

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ positional arguments:
   {aws,azure,bind,cloudflare,file,single}
 
 options:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit
   --out OUT             Output file (default: results) - use 'stdout' to stream out
   --out-format {csv,json}
   --parallelism PARALLELISM

--- a/argparsing.py
+++ b/argparsing.py
@@ -88,11 +88,7 @@ parser.add_argument(
     action='help',
     help="Show this help message and exit",
 )
-# if self.add_help:
-#             self.add_argument(
-#                 default_prefix+'h', default_prefix*2+'help',
-#                 action='help', default=SUPPRESS,
-#                 help=_('show this help message and exit'))
+
 parser.add_argument(
     "--out",
     type=str,

--- a/argparsing.py
+++ b/argparsing.py
@@ -63,6 +63,7 @@ providers:
 """,
     formatter_class=argparse.RawDescriptionHelpFormatter,
     description="",
+    add_help=False
 )
 
 parser.add_argument(
@@ -81,6 +82,17 @@ for provider in providers.__all__:
             type=str,
         )
 
+parser.add_argument(
+    "-h",
+    "--help",
+    action='help',
+    help="Show this help message and exit",
+)
+# if self.add_help:
+#             self.add_argument(
+#                 default_prefix+'h', default_prefix*2+'help',
+#                 action='help', default=SUPPRESS,
+#                 help=_('show this help message and exit'))
 parser.add_argument(
     "--out",
     type=str,


### PR DESCRIPTION
Found that the description of all inline options (arguments) is uniform except --help option. Capitalized the description of --help command also. 
```diff
options:
-  -h, --help            show this help message and exit
+  -h, --help            Show this help message and exit
  --out OUT             Output file (default: results) - use 'stdout' to stream out
  --out-format {csv,json}
  --parallelism PARALLELISM
                        Number of domains to test in parallel - too high and you may see odd DNS results (default: 30)
  --disable-probable    Do not check for probable conditions
  --enable-unlikely     Check for more conditions, but with a high false positive rate
...
```