### PR TITLE
Add support for alternate AWS auth options (#77)

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,8 @@ python main.py --help
 * Scan AWS account:
 
     ``` docker run punksecurity/dnsreaper aws --aws-access-key-id <key> --aws-access-key-secret <secret> ```
+
+    For more information, see [the documentation for the aws provider](/docs/aws.md)
 * Scan all domains from file:
 
     ``` docker run -v $(pwd):/etc/dnsreaper punksecurity/dnsreaper file --filename /etc/dnsreaper/<filename> ```

--- a/docs/aws.md
+++ b/docs/aws.md
@@ -1,10 +1,27 @@
 # AWS
 
+## Description
 The AWS provider connects to AWS and fetches all public zones and then enumerates the records in these zones.
 
 To enumerate Route53 zones, you need to provide an access key id and secret with IAM permissions
 to list and get Route53 zones.  This is done through standard switches like all other options.
 
+
+## Usage
+The command-line options `--aws-access-key-id` and `--aws-access-key-secret` can be used to specify credentials.
+
+If you do not provide these options, the AWS provider will use the following ways of obtaining credentials, in order:
+1. Environment variables
+2. Shared credential file (~/.aws/credentials)
+3. AWS config file (~/.aws/config)
+4. Assume Role provider
+5. Boto2 config file (/etc/boto.cfg and ~/.boto)
+6. Instance metadata service on an Amazon EC2 instance that has an IAM role configured.
+
+For more information, please see the
+[boto3 documentation](https://boto3.amazonaws.com/v1/documentation/api/latest/guide/credentials.html).
+
+## Requirements
 As a minimum you need:
 * GetHostedZone
 * ListHostedZones

--- a/providers/aws.py
+++ b/providers/aws.py
@@ -53,7 +53,15 @@ def get_zones(client):
     return public_zones
 
 
-def fetch_domains(aws_access_key_id, aws_access_key_secret, **args):
+def validate_args(aws_access_key_id, aws_access_key_secret):
+    if aws_access_key_id is not None and aws_access_key_secret is None:
+        raise ValueError("--aws-access-key-secret must be specified if --aws-access-key-id is specified")
+    if aws_access_key_secret is not None and aws_access_key_id is None:
+        raise ValueError("--aws-access-key-id must be specified if --aws-access-key-secret is specified")
+
+
+def fetch_domains(aws_access_key_id=None, aws_access_key_secret=None):
+    validate_args(aws_access_key_id, aws_access_key_secret)
     domains = []
     client = boto3.client(
         "route53",

--- a/providers/readme.md
+++ b/providers/readme.md
@@ -15,6 +15,7 @@ def fetch_domains(argumentA, argumentB **args):
 The description and provider file name are used to configure the argument parser and help menu.
 
 The fetch_domains function can take any number of arguments, and these are automatically added to the argument parsers and help menu.
+To make an argument optional, give it a default value. 
 
 For full details on individual providers, please visit [docs](../docs/README.md)
 


### PR DESCRIPTION
Resolves #77.

If `--aws-access-key-id` and `--aws-access-key-secret` are not provided on the command-line, it allows boto3 to source the credentials itself.

This also enhances the argument parsing by allowing providers to decide whether options are required or not. Options are required by default, but can be made non-required by giving them a default value in the function signature:
```python
def fetch_domains(aws_access_key_id=None, aws_access_key_secret=None, **args):
```

