### PR TITLE
AWS Provider: Check if a record is an Alias record

### DIFF
--- a/providers/aws.py
+++ b/providers/aws.py
@@ -20,9 +20,14 @@ def convert_records_to_domains(records):
     for record in records:
         if record["Name"] not in buf.keys():
             buf[record["Name"]] = {}
-        buf[record["Name"]][record["Type"]] = [
-            r["Value"] for r in record["ResourceRecords"]
-        ]
+        if "ResourceRecords" in record:
+            buf[record["Name"]][record["Type"]] = [
+                r["Value"] for r in record["ResourceRecords"]
+            ]
+        elif "AliasTarget" in record:
+            buf[record["Name"]][record["Type"]] = [
+                record["AliasTarget"]["DNSName"]
+            ]
     for subdomain in buf.keys():
         domain = Domain(subdomain.rstrip("."), fetch_standard_records=False)
         if "A" in buf[subdomain].keys():


### PR DESCRIPTION
Alias records don't have a `ResourceRecords` key, instead they have `AliasTarget`

Fixes: #88 