### PR TITLE
Add google-cloud-dns to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ colorama==0.4.5
 azure-mgmt-dns==8.0.0
 azure-identity==1.10.0
 msrestazure==0.6.4
+google-cloud-dns==0.34.1


### PR DESCRIPTION
Adding this package as it is required for the code added in #164.

Tested with `pip install -r requirements.txt`.