### PR TITLE
Fix paging in Cloudflare zone fetch

### DIFF
--- a/providers/cloudflare.py
+++ b/providers/cloudflare.py
@@ -59,7 +59,7 @@ def get_zones(client):
     while True:
         page_number += 1
         try:
-            raw_results = client.zones.get()
+            raw_results = client.zones.get(params={"page": page_number})
         except CloudFlare.exceptions.CloudFlareAPIError as e:
             exit(f"/zones.get api call failed {e}")
         except Exception as e:


### PR DESCRIPTION
Fixes an issue where Cloudflare zones beyond the first page would not be fetched.

Change: Add page parameter to the Cloudflare provider zone fetch.
