### PR TITLE
Make relative names in AXFR into FQDN

### DIFF
--- a/providers/zonetransfer.py
+++ b/providers/zonetransfer.py
@@ -31,7 +31,15 @@ def convert_records_to_domains(root_domain, records):
             continue
 
         if record_type == record_types.CNAME:
-            buf[fqdn]["CNAME"] = [str(x) for x in record_items]
+            cna = []
+            for x in record_items:
+                cn = str(x)
+                if cn.endswith("."):
+                    cna.append(cn)
+                else:
+                    cna.append(f"{cn}.{root_domain}")
+
+            buf[fqdn]["CNAME"] = cna
             continue
 
         if record_type == record_types.NS:


### PR DESCRIPTION
In the zonetransfer provider the RHS of a CNAME may be a relative name not necessarily a FQDN.  So for example

> www.example.com CNAME webserver

instead of

> www.example.com CNAME webserver.example.com.

Note significant ending `.` in the second example.  This PR makes relative names into FQDNs.