### PR TITLE
Add Proposify Signature

### DIFF
--- a/signatures/proposify.py
+++ b/signatures/proposify.py
@@ -1,0 +1,10 @@
+from .templates.cname_found_but_string_in_body import cname_found_but_string_in_body
+from detection_enums import CONFIDENCE
+
+test = cname_found_but_string_in_body(
+    cname="ssl.proposify.com",
+    domain_not_configured_message="Why isn't my custom domain showing?",
+    service="app.proposify.com",
+    confidence=CONFIDENCE.POTENTIAL,
+    custom_uri="/domain",
+)


### PR DESCRIPTION
Condition: ssl.proposify.com as CNAME.

Cannot positively confirm without either:

1. Knowing a proposal link to check if active
2. Registering domain under an active proposify account.