### PR TITLE
Fix for cyclical CNAMEs causing infinite loop

### DIFF
--- a/domain.py
+++ b/domain.py
@@ -58,7 +58,7 @@ class Domain:
             await d.fetch_std_records()
             self.A += d.A
             self.AAAA += d.AAAA
-            self.CNAME += d.CNAME
+            self.CNAME = list(set(self.CNAME + d.CNAME))
         for ns in self.NS:
             try:
                 d = Domain(self.domain)


### PR DESCRIPTION
Cyclical CNAMEs can cause an infinite loop when fetching external records, this pull request fixes this by not adding already seen CNAMEs to self.CNAME
![image](https://github.com/user-attachments/assets/87f9999e-6863-49f4-8e62-8547f3dd2f81)
