### PR TITLE
Update signatures

### DIFF
--- a/domain.py
+++ b/domain.py
@@ -140,7 +140,8 @@ class Domain:
                 resp = await session.get(url, ssl=ssl_context, headers=headers)
                 web_status = resp.status
                 web_body = await resp.text()
-        except:
+        except Exception as exc:
+            logging.debug(f"Web request to '{url}' failed: {exc}")
             web_status = 0
             web_body = ""
         return namedtuple("web_response", ["status_code", "body"])(web_status, web_body)

--- a/signatures/aha.py
+++ b/signatures/aha.py
@@ -2,6 +2,6 @@ from .templates.cname_found_but_string_in_body import cname_found_but_string_in_
 
 test = cname_found_but_string_in_body(
     cname=".aha.io",
-    domain_not_configured_message="Unable to load ideas portal",
+    domain_not_configured_message="invalid-portal",
     service="aha.io",
 )

--- a/signatures/bettermode.py
+++ b/signatures/bettermode.py
@@ -1,0 +1,7 @@
+from .templates.cname_found_but_status_code import cname_found_but_status_code
+
+test = cname_found_but_status_code(
+    cname="domains.bettermode.io",
+    code=409,
+    service="bettermode.com",
+)

--- a/signatures/checks/WEB.py
+++ b/signatures/checks/WEB.py
@@ -7,13 +7,13 @@ import sys
 async def string_in_body(
     domain: Domain, string: str, https: bool, custom_uri: str = ""
 ) -> bool:
-    if string in (await domain.fetch_web(https=https, uri=custom_uri)).body:
+    body = (await domain.fetch_web(https=https, uri=custom_uri)).body
+    if string in body:
         logging.info(f"Message observed in response for '{domain}'")
         return True
     logging.debug(f"Message not found in response for '{domain}'")
-    # Uncomment to debug and identify a string match issue
     if "pytest" in sys.modules:
-        logging.warning((await domain.fetch_web(https=https, uri=custom_uri)).body)
+        logging.warning(f"{body=}")
     return False
 
 

--- a/signatures/hatenablog.py
+++ b/signatures/hatenablog.py
@@ -2,7 +2,7 @@ from .templates.cname_found_but_string_in_body import cname_found_but_string_in_
 
 test = cname_found_but_string_in_body(
     cname=".hatenablog.com",
-    domain_not_configured_message="404 Blog is not found",
+    domain_not_configured_message="The request could not be satisfied.",
     service="hatenablog.com",
-    https=True,
+    https=False,
 )

--- a/signatures/helpscout.py
+++ b/signatures/helpscout.py
@@ -1,8 +1,7 @@
-from .templates.cname_found_but_string_in_body import cname_found_but_string_in_body
+from .templates.cname_found_but_status_code import cname_found_but_status_code
 
-test = cname_found_but_string_in_body(
+test = cname_found_but_status_code(
     cname="cname.helpscoutdocs.com",
-    domain_not_configured_message="Not Found",
+    code=0,
     service="helpscoutdocs.com",
-    https=True,
 )

--- a/signatures/shopify.py
+++ b/signatures/shopify.py
@@ -10,7 +10,7 @@ cname = "shops.myshopify.com"
 test = cname_or_ip_found_but_string_in_body(
     cname=cname,
     ips=ipv4 + ipv6,
-    domain_not_configured_message="This domain points to Shopify but isn't configured properly",
+    domain_not_configured_message="Cloudflare is currently unable to resolve your requested domain",
     service="Shopify",
 )
 

--- a/signatures/teamwork.py
+++ b/signatures/teamwork.py
@@ -2,8 +2,8 @@ from .templates.cname_found_but_string_in_body import cname_found_but_string_in_
 
 test = cname_found_but_string_in_body(
     cname=".teamwork.com",
-    domain_not_configured_message="""Unable to determine installationID from domain""",
+    domain_not_configured_message="The request could not be satisfied.",
     service="teamwork",
     custom_uri="launchpad/v1/info.json",
-    https=True,
+    https=False,
 )

--- a/signatures/tribe.py
+++ b/signatures/tribe.py
@@ -1,7 +1,0 @@
-from .templates.cname_found_but_status_code import cname_found_but_status_code
-
-test = cname_found_but_status_code(
-    cname="domains.tribeplatform.com",
-    code=0,
-    service="tribe.so",
-)


### PR DESCRIPTION
Fixed signatures:

Tribe: Replace with BetterMode as service has been replaced
Shopify: Match on Cloudflare error page
TeamWork, HatenaBlog: Disable HTTPS and match on Cloudfront error page
HelpScout: Match on status code 0
Aha: Match on invalid-portal string as error page seems to have variable language

Other changes:
domain.py: Log exceptions that occur during fetch_web to assist in debugging as these were previously being swallowed by a broad except statement
WEB.py: Avoid fetching request body twice when testing within PyTest and use an f-string for debug logging the request body for clearer visibility of empty responses
